### PR TITLE
Update link to resource browser to use notebook pages

### DIFF
--- a/docs/platform_example_analyses.md
+++ b/docs/platform_example_analyses.md
@@ -1,7 +1,7 @@
 
 # Example Analyses
 
-[The Example Analysis page](https://healdata.org/portal/resource-browser) contains a collection of view-only tutorial Jupyter Notebooks that provide demo analyses of datasets published on the HEAL platform.
+[The Example Analysis page](https://uc-cdis.github.io/heal-notebooks-pages/) contains a collection of view-only tutorial Jupyter Notebooks that provide demo analyses of datasets published on the HEAL platform.
 
 > This tab acts as a ['visual table of contents’](#currently-available-notebooks) of available HEAL datasets.
 

--- a/docs/platform_workspaces.md
+++ b/docs/platform_workspaces.md
@@ -20,7 +20,7 @@ Available workspaces on the HEAL Platform (top). Users may need to link their ac
 * **(Generic, User-licensed) Stata Notebook:** Choose this VM if you are familiar with Stata-based data analysis. This notebook requires a Stata license.
 * **Tutorial Notebooks:** Explore our Jupyter Notebook tutorials written in Python or RStudio, which pull data from various sources of the HEAL Data Ecosystem to leverage statistical programs and data analysis tools.  
 
-All interactive tutorial notebooks can be also found as [static version on the Notebook Browser tab](https://healdata.org/portal/resource-browser); read more in the section ["Example Analysis"](platform_example_analyses.md).  
+All interactive tutorial notebooks can be also found as [static version on the Notebook Browser tab](https://uc-cdis.github.io/heal-notebooks-pages/); read more in the section ["Example Analysis"](platform_example_analyses.md).  
 
 Feel free to edit and experiment with this collection of notebooks. They are your personal copies!  
 

--- a/docs/workspaces/heal_workspaces.md
+++ b/docs/workspaces/heal_workspaces.md
@@ -18,7 +18,7 @@ Once you have access to workspaces, use this guide below to get started with ana
       ![Screenshot of different workspace images](../img/HEAL_workspaces_flavors.png)
 
       - **(Generic) Jupyter Notebook with R kernel:** Choose this VM if you are familiar with setting up Python- or R-based Notebooks, or if you just exported one or multiple studies from the Discovery Page and want to start your custom analysis.
-      - **Tutorial Notebooks:** Explore our [Jupyter Notebook tutorials](https://healdata.org/portal/resource-browser) written in Python or R, which analyze data pulled from various sources on the HEAL Data Platform These are excellent resources for code to use to analyze data from HEAL, and examples that illustrate the variety of data and analyses available through HEAL.
+      - **Tutorial Notebooks:** Explore our [Jupyter Notebook tutorials](https://uc-cdis.github.io/heal-notebooks-pages/) written in Python or R, which analyze data pulled from various sources on the HEAL Data Platform These are excellent resources for code to use to analyze data from HEAL, and examples that illustrate the variety of data and analyses available through HEAL.
 
 3. Click “Launch” on any of the workspace options to spin up a copy of that VM. The status of launching the workspace is displayed after clicking on “Launch”. Note: Launching the VM may take several minutes.
 


### PR DESCRIPTION
Update obsolete links to the resource browser page to instead point to https://uc-cdis.github.io/heal-notebooks-pages/